### PR TITLE
#1 Track selected connections so the lately used ones would be on top of the list

### DIFF
--- a/RDP.cs
+++ b/RDP.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -5,111 +6,166 @@ using System.Linq;
 using System.Windows.Controls;
 using Microsoft.Win32;
 
-namespace Flow.Launcher.Plugin.RDP {
+namespace Flow.Launcher.Plugin.RDP;
+
+/// <summary>
+/// Flow.Launcher.Plugin.RDP 
+/// </summary>
+public class RDP : IPlugin, ISettingProvider
+{
+    private PluginInitContext _context;
+    private Settings _settings;
+    private RDPConnections _rdpConnections;
+    private RDPConnectionsStore _store;
+    private SearchPhraseProvider _searchPhraseProvider;
+
+
     /// <summary>
-    /// Flow.Launcher.Plugin.RDP 
+    /// initialize the plugin.
     /// </summary>
-    public class RDP : IPlugin, ISettingProvider {
+    /// <param name="context"></param>
+    public void Init(PluginInitContext context)
+    {
+        _context = context;
+        _store = new RDPConnectionsStore(Path.Combine(
+            context.CurrentPluginMetadata.PluginDirectory,
+            "data",
+            "connections.txt"));
+        _rdpConnections = _store.Load();
+        _searchPhraseProvider = new SearchPhraseProvider();
 
-        internal PluginInitContext Context;
-        private Settings settings;
+        // initialize template settings. right now there are no settings.
 
+        #region init settings
 
-        /// <summary>
-        /// initialize the plugin.
-        /// </summary>
-        /// <param name="context"></param>
-        public void Init(PluginInitContext context) {
-            Context = context;
-
-            // initialize template settings. right now there are no settings.
-            #region init settings
-            var settingsFolderLocation =
-                Path.Combine(
-                    Directory.GetParent(
+        var settingsFolderLocation =
+            Path.Combine(
+                Directory.GetParent(
                         Directory.GetParent(context.CurrentPluginMetadata.PluginDirectory).FullName)
                     .FullName,
-                    "Settings", "Plugins", "Flow.Launcher.Plugin.RDP");
+                "Settings", "Plugins", "Flow.Launcher.Plugin.RDP");
 
-            var settingsFileLocation = Path.Combine(settingsFolderLocation, "Settings.json");
+        var settingsFileLocation = Path.Combine(settingsFolderLocation, "Settings.json");
 
-            if (!Directory.Exists(settingsFolderLocation)) {
-                Directory.CreateDirectory(settingsFolderLocation);
+        if (!Directory.Exists(settingsFolderLocation))
+        {
+            Directory.CreateDirectory(settingsFolderLocation);
 
-                settings = new Settings {
-                    SettingsFileLocation = settingsFileLocation
-                };
-
-                settings.Save();
-            }
-            #endregion
-        }
-
-
-        /// <summary>
-        /// return results for the given query, starting with rpd
-        /// </summary>
-        /// <param name="query">search query provided by flow-launcher</param>
-        /// <returns></returns>
-        public List<Result> Query(Query query) {
-            // initialize a empty result list
-            var results = new List<Result>();
-            // read the registry to get historical rdp sessions of the current user
-            RegistryKey key = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Terminal Server Client\\Servers");
-            // create the default result for a new rdp connection with no given host
-            results.Add(CreateDefaultResult());
-            // check if the user is searching for a connection
-            // if not, show him all historic rdp connections found in the registry
-            if (string.IsNullOrEmpty(query.Search)) {
-                foreach (string item in key.GetSubKeyNames()) {
-                    results.Add(new Result { Title = item, SubTitle = "Connect to this host via RDP", IcoPath = "screen-mirroring.png" });
-                }
-            }
-            // if the user has typed a search query, show him matching results from the registry
-            else {
-                List<string> subKeys = key.GetSubKeyNames().ToList<string>().Where(x => x.Contains(query.Search)).ToList<string>();
-                // add a result for each matching result
-                foreach (var item in subKeys) {
-                    results.Add(new Result {
-                        Title = item,
-                        SubTitle = "Connect to this host via RDP",
-                        IcoPath = "screen-mirroring.png",
-                        Action = c => {
-                            Process.Start("mstsc", "/v:" + item);
-                            return true;
-                        }
-                    });
-                }
-            }
-            // return results to flow-launcher.
-            return results;
-        }
-
-
-        /// <summary>
-        /// create the settings pane inside flow-launchers plugins page.
-        /// </summary>
-        /// <returns></returns>
-        public Control CreateSettingPanel() {
-            return new SettingsUserControl(settings);
-        }
-
-
-        /// <summary>
-        /// create the default result for a new rdp connection with no given host
-        /// </summary>
-        /// <returns>default result</returns>
-        private Result CreateDefaultResult() {
-            return new Result {
-                Title = "RDP",
-                SubTitle = "Establish a new RDP connection",
-                IcoPath = "screen-mirroring.png",
-                Score = 50,
-                Action = c => {
-                    Process.Start("mstsc");
-                    return true;
-                }
+            _settings = new Settings
+            {
+                SettingsFileLocation = settingsFileLocation
             };
+
+            _settings.Save();
         }
+
+        #endregion
+    }
+
+
+    /// <summary>
+    /// return results for the given query, starting with rpd
+    /// </summary>
+    /// <param name="query">search query provided by flow-launcher</param>
+    /// <returns></returns>
+    public List<Result> Query(Query query)
+    {
+        _searchPhraseProvider.Search = query.Search;
+        _rdpConnections.Reload(GetRdpConnectionsFromRegistry());
+
+        var connections = _rdpConnections.FindConnections(query.Search);
+
+        var results = new[] { CreateDefaultResult() }
+            .Concat(connections.Select(MapToResult))
+            .ToList();
+
+        LogResults(results);
+
+        return results;
+    }
+
+
+    /// <summary>
+    /// create the settings pane inside flow-launchers plugins page.
+    /// </summary>
+    /// <returns></returns>
+    public Control CreateSettingPanel()
+    {
+        return new SettingsUserControl(_settings);
+    }
+
+    private static IReadOnlyCollection<string> GetRdpConnectionsFromRegistry()
+    {
+        var key = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Terminal Server Client\Servers");
+        if (key is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        return key.GetSubKeyNames();
+    }
+
+    private Result MapToResult((string connection, int score) item) =>
+        new()
+        {
+            // For some reason SubTitle must be unique otherwise score is not respected
+            Title = $"{item.connection}",
+            SubTitle = $"Connect to {item.connection} via RDP",
+            IcoPath = "screen-mirroring.png",
+            Score = item.score,
+            Action = c =>
+            {
+                _rdpConnections.ConnectionWasSelected(item.connection);
+                _store.Save(_rdpConnections);
+
+                StartMstsc(item.connection);
+                return true;
+            }
+        };
+
+
+    private void LogResults(IReadOnlyCollection<Result> results)
+    {
+        _context.API.LogInfo("RDP", "Results: ");
+        foreach (var result in results)
+        {
+            _context.API.LogInfo("RDP", $"{result.Title} - {result.Score}");
+        }
+    }
+
+    private Result CreateDefaultResult() =>
+        new()
+        {
+            Title = "RDP",
+            SubTitle = "Establish a new RDP connection",
+            IcoPath = "screen-mirroring.png",
+            Score = 100,
+            Action = c =>
+            {
+                StartMstsc(_searchPhraseProvider.Search);
+                return true;
+            }
+        };
+
+    private static void StartMstsc(string connection)
+    {
+        if (string.IsNullOrWhiteSpace(connection))
+        {
+            Process.Start("mstsc");
+        }
+        else
+        {
+            Process.Start("mstsc", "/v:" + connection);
+        }
+    }
+
+    /// <summary>
+    /// In order to have a newest search phrase in Result.Action lambda.
+    /// Passing unwrapped Search string to Action for some reason doesn't work,
+    /// since it keeps the value of first search which is empty string 
+    /// </summary>
+    private class SearchPhraseProvider
+    {
+        public string Search { get; set; }
     }
 }

--- a/RDPConnections.cs
+++ b/RDPConnections.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Flow.Launcher.Plugin.RDP;
+
+internal class RDPConnections
+{
+    private readonly List<string> _connections;
+
+    private RDPConnections(IEnumerable<string> connections)
+    {
+        _connections = connections.ToList();
+    }
+
+    public static RDPConnections Create(IEnumerable<string> connections) => new(connections);
+
+    public IReadOnlyCollection<string> Connections => _connections;
+
+    public void Reload(IReadOnlyCollection<string> rdpConnections)
+    {
+        var newConnections = rdpConnections.Where(x => !_connections.Contains(x)).ToList();
+        var oldConnections = _connections.Where(x => !rdpConnections.Contains(x)).ToList();
+
+        foreach (var oldConnection in oldConnections)
+        {
+            _connections.Remove(oldConnection);
+        }
+
+        _connections.AddRange(newConnections);
+    }
+
+    public void ConnectionWasSelected(string connection)
+    {
+        var index = _connections.IndexOf(connection);
+        if (index == -1)
+        {
+            return;
+        }
+
+        _connections.RemoveAt(index);
+        _connections.Insert(0, connection);
+    }
+
+    public IReadOnlyCollection<(string Connection, int Score)> FindConnections(string querySearch)
+    {
+        if (string.IsNullOrWhiteSpace(querySearch))
+        {
+            return _connections
+                .Select(MapToScore)
+                .ToList();
+        }
+
+        return _connections
+            .Where(x => x.Contains(querySearch, StringComparison.InvariantCultureIgnoreCase))
+            .Select(MapToScore)
+            .ToList();
+    }
+
+    private (string connection, int score) MapToScore(string x, int i) => (connection: x, score: _connections.Count + 1 - i);
+}

--- a/RDPConnectionsStore.cs
+++ b/RDPConnectionsStore.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Flow.Launcher.Plugin.RDP;
+
+internal class RDPConnectionsStore
+{
+    private readonly string _storageFile;
+
+    public RDPConnectionsStore(string storageFile)
+    {
+        _storageFile = storageFile;
+    }
+
+    public RDPConnections Load()
+    {
+        EnsureDirectoryExists();
+
+        var lines = new List<string>();
+
+        using var fileStream = new FileStream(
+            _storageFile,
+            FileMode.OpenOrCreate,
+            FileAccess.Read,
+            FileShare.ReadWrite);
+        using var reader = new StreamReader(fileStream);
+
+        while (reader.ReadLine() is { } line)
+        {
+            lines.Add(line);
+        }
+
+        return RDPConnections.Create(lines);
+    }
+
+    public void Save(RDPConnections rdpConnections)
+    {
+        EnsureDirectoryExists();
+
+        var lines = rdpConnections.Connections;
+
+        using var fileStream = new FileStream(
+            _storageFile,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.Read);
+        using var writer = new StreamWriter(fileStream);
+
+        foreach (var line in lines)
+        {
+            writer.WriteLine(line);
+        }
+    }
+
+    private void EnsureDirectoryExists()
+    {
+        var directory = Path.GetDirectoryName(_storageFile);
+        if (directory is not null)
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+}

--- a/publish-local.ps1
+++ b/publish-local.ps1
@@ -1,0 +1,3 @@
+Stop-Process -Name "Flow.Launcher" -Force
+dotnet publish -o "$env:LOCALAPPDATA\FlowLauncher\app-1.16.2\Plugins\Flow.Launcher.Plugin.RDP"
+Start-Process "$env:LOCALAPPDATA\FlowLauncher\Flow.Launcher.exe"


### PR DESCRIPTION
#1
* In order to not lose track of lately used connections after a Flow Launcher reboot they are kept in file
* There is strange behaviour of Flow Launcher, score is not respected if the SubTitle is the same between different results, therefore I've added a connection to it so they would be unique.

I've also added a change that mstsc is started with a provided search string as a connection parameter 
so it would be possible to just type `rdp some.dns.name` and open a rdp pointing to that server.

EDIT:
Actually, after checking once again a description of issue I'm not sure right now if I had correctly understood it.
I've done this favourite list in such a way that I'm putting on top of the list those connections which were lately used.
So for example if you got:
1.1.1.1
2.2.2.2
3.3.3.3
4.4.4.4
and you select/connect to 3.3.3.3 and then to 4.4.4.4
you will get in the next search
4.4.4.4
3.3.3.3
1.1.1.1
2.2.2.2